### PR TITLE
Ensure all the buttons in the bottom toolbar have the same height

### DIFF
--- a/app/src/main/res/layout/article.xml
+++ b/app/src/main/res/layout/article.xml
@@ -53,13 +53,13 @@
                 <LinearLayout
                     android:id="@+id/bottomTools"
                     android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
+                    android:layout_height="wrap_content"
                     android:orientation="horizontal"
                     android:visibility="gone">
                     <ImageButton
                         android:id="@+id/btnGoPrevious"
                         android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:contentDescription="@string/menuPrevious"
                         android:src="@drawable/ic_action_previous_item"
                         android:layout_weight="1"/>
@@ -79,7 +79,7 @@
                     <ImageButton
                         android:id="@+id/btnGoNext"
                         android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:contentDescription="@string/menuNext"
                         android:src="@drawable/ic_action_next_item"
                         android:layout_weight="1"/>


### PR DESCRIPTION
Addition to wallabag/android-app#537.

If I understand layouts correctly, this should stretch `ImageButton`s vertically *if needed* (not sure it will ever be needed, though).